### PR TITLE
Remove optional fields from PropertyGuru extractor CSV

### DIFF
--- a/propertyguru_extract_spyder.py
+++ b/propertyguru_extract_spyder.py
@@ -844,28 +844,28 @@ def run():
     ]
 
     extra_fieldnames = [
-        "file",
-        "address",
-        "subarea",
-        "lister_url",
-        "agency_registration_number",
-        "price_per_square_feet",
-        "furnishing_source",
-        "tenure",
-        "property_title",
-        "bumi_lot",
-        "total_units",
-        "completion_year",
-        "developer",
-        "amenities",
-        "facilities",
-        "scrape_unix",
+        # "file",
+        # "address",
+        # "subarea",
+        # "lister_url",
+        # "agency_registration_number",
+        # "price_per_square_feet",
+        # "furnishing_source",
+        # "tenure",
+        # "property_title",
+        # "bumi_lot",
+        # "total_units",
+        # "completion_year",
+        # "developer",
+        # "amenities",
+        # "facilities",
+        # "scrape_unix",
     ]
 
     fieldnames = primary_fieldnames + extra_fieldnames
 
     with open(out_csv, "w", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
         writer.writeheader()
         writer.writerows(rows)
 


### PR DESCRIPTION
## Summary
- stop writing ancillary PropertyGuru fields to the exported CSV by commenting them out
- ignore any remaining extra keys when serialising rows so CSV generation continues to work

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6255fd2c88332838502b39b65378b